### PR TITLE
Remove unused Logger

### DIFF
--- a/source/Core/Configuration/Hosting/ErrorPageFilterAttribute.cs
+++ b/source/Core/Configuration/Hosting/ErrorPageFilterAttribute.cs
@@ -26,9 +26,7 @@ using System.Web.Http.Filters;
 namespace IdentityServer3.Core.Configuration.Hosting
 {
     internal class ErrorPageFilterAttribute : ExceptionFilterAttribute
-    {
-        private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
-        
+    {   
         public override async System.Threading.Tasks.Task OnExceptionAsync(HttpActionExecutedContext actionExecutedContext, System.Threading.CancellationToken cancellationToken)
         {
             var env = actionExecutedContext.ActionContext.Request.GetOwinEnvironment();


### PR DESCRIPTION
All exceptions are logged by IExceptionLogger attached into WebApi middleware.
Here: https://github.com/IdentityServer/IdentityServer3/blob/master/source/Core/Configuration/Hosting/LogProviderExceptionLogger.cs